### PR TITLE
Add Cloth Config API as dependency list

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,6 +24,7 @@
 	"depends": {
 		"fabricloader": ">=0.14.9",
 		"minecraft": ">=26.1",
-		"java": ">=17"
+		"java": ">=17",
+		"cloth-config": "*"
 	}
 }


### PR DESCRIPTION
This should prevent crashes for not having Cloth Config API and instead display warning that you need Cloth Config API.